### PR TITLE
Adding fft_based_translation_initialization method.

### DIFF
--- a/SimpleITK/utilities/__init__.py
+++ b/SimpleITK/utilities/__init__.py
@@ -19,6 +19,7 @@
 from .Logger import Logger
 from .slice_by_slice import slice_by_slice
 from .make_isotropic import make_isotropic
+from .fft import fft_based_translation_initialization
 
 try:
     from ._version import version as __version__
@@ -26,7 +27,13 @@ except ImportError:
     __version__ = "unknown version"
 
 
-__all__ = ["Logger", "slice_by_slice", "make_isotropic", "__version__"]
+__all__ = [
+    "Logger",
+    "slice_by_slice",
+    "make_isotropic",
+    "fft_based_translation_initialization",
+    "__version__",
+]
 
 import importlib
 

--- a/SimpleITK/utilities/fft.py
+++ b/SimpleITK/utilities/fft.py
@@ -1,0 +1,62 @@
+import SimpleITK as sitk
+
+
+def fft_based_translation_initialization(
+    fixed: sitk.Image, moving: sitk.Image
+) -> sitk.TranslationTransform:
+    """
+    Perform fast Fourier transform based normalized correlation to find the translation of the maximize correlation
+     between the images.
+
+    If the moving image grid is not congruent with fixed image ( same origin, spacing and direction ), then it will be
+    resampled onto the grid defined by the fixed image.
+
+    Efficiency can be improved by reducing the resolution of the image or using a projection filter to reduce the
+    dimensionality of the inputs.
+
+    :param fixed: A SimpleITK image object
+    :param moving: Another SimpleITK Image object, which will be resampled onto the grid of the fixed image if it is not
+    congruent.
+    :return: A TranslationTransform mapping physical points from the fixed to the moving image.
+    """
+
+    if (
+        moving.GetSpacing() != fixed.GetSpacing()
+        or moving.GetDirection() != fixed.GetDirection()
+        or moving.GetOrigin() != fixed.GetOrigin()
+    ):
+        resampler = sitk.ResampleImageFilter()
+        resampler.SetReferenceImage(fixed)
+        moving = resampler.Execute(moving)
+
+    sigma = fixed.GetSpacing()[0]
+    pixel_type = sitk.sitkFloat32
+
+    fft_fixed = sitk.Cast(sitk.SmoothingRecursiveGaussian(fixed, sigma), pixel_type)
+    fft_moving = sitk.Cast(sitk.SmoothingRecursiveGaussian(moving, sigma), pixel_type)
+
+    out = sitk.FFTNormalizedCorrelation(fft_fixed, fft_moving)
+
+    out = sitk.SmoothingRecursiveGaussian(out)
+    cc = sitk.ConnectedComponent(sitk.RegionalMaxima(out, fullyConnected=True))
+    stats = sitk.LabelStatisticsImageFilter()
+    stats.Execute(out, cc)
+    labels = sorted(stats.GetLabels(), key=lambda l: stats.GetMean(l))
+
+    peak_bb = stats.GetBoundingBox(labels[-1])
+    # Add 0.5 for center of voxel on continuous index
+    peak_idx = [
+        (min_idx + max_idx) / 2.0 + 0.5
+        for min_idx, max_idx in zip(peak_bb[0::2], peak_bb[1::2])
+    ]
+
+    peak_pt = out.TransformContinuousIndexToPhysicalPoint(peak_idx)
+    peak_value = stats.GetMean(labels[-1])
+
+    center_pt = out.TransformContinuousIndexToPhysicalPoint(
+        [p / 2.0 for p in out.GetSize()]
+    )
+
+    translation = [c - p for c, p in zip(center_pt, peak_pt)]
+
+    return sitk.TranslationTransform(out.GetDimension(), translation)

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -35,3 +35,29 @@ def test_slice_by_slice():
 def test_sitktovtk():
     img = sitk.Image([10, 10, 5], sitk.sitkFloat32)
     vtk_img = sitkutils.sitk2vtk(img)
+
+
+def test_fft_initialization():
+    fixed_img = sitk.Image([1024, 512], sitk.sitkInt8)
+
+    fixed_img[510:520, 255:265] = 10
+
+    moving_img = sitk.Image([1024, 512], sitk.sitkInt8)
+    moving_img[425:435, 300:320] = 8
+
+    tx = sitkutils.fft_based_translation_initialization(fixed_img, moving_img)
+    assert tx.GetOffset() == (-85.0, 50.0)
+
+
+def test_fft_initialization2():
+    fixed_img = sitk.Image([1024, 512], sitk.sitkUInt8)
+
+    fixed_img[510:520, 255:265] = 10
+
+    moving_img = sitk.Image([1024, 512], sitk.sitkUInt8)
+    moving_img.SetSpacing([1, 0.5])
+    moving_img.SetOrigin([0, -0.25])
+    moving_img[425:435, 305:315] = 8
+
+    tx = sitkutils.fft_based_translation_initialization(fixed_img, moving_img)
+    assert tx.GetOffset() == (-85.0, -105.0)


### PR DESCRIPTION
Based on previous work to efficient initialize registraion of large micrscopy images ( the images were reduced in resolition before the fft correlation was done).