### PR TITLE
Move VTK utilities to sub-module

### DIFF
--- a/SimpleITK/utilities/__init__.py
+++ b/SimpleITK/utilities/__init__.py
@@ -38,17 +38,3 @@ __all__ = [
     "resize",
     "__version__",
 ]
-
-from importlib.util import find_spec
-
-try:
-    find_spec("vtk")
-    from .vtk import sitk2vtk, vtk2sitk
-
-    __all__.extend(["sitk2vtk", "vtk2sitk"])
-
-    _has_vtk = True
-except ImportError:
-    _has_vtk = False
-
-del find_spec

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,5 +7,8 @@ API
 .. automodule:: SimpleITK.utilities.dask
     :members:
 
+.. automodule:: SimpleITK.utilities.pyside
+    :members
+
 .. automodule:: SimpleITK.utilities.vtk
     :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,3 +6,6 @@ API
 
 .. automodule:: SimpleITK.utilities.dask
     :members:
+
+.. automodule:: SimpleITK.utilities.vtk
+    :members:

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -1,10 +1,7 @@
 import math
-import gc
-
 import SimpleITK as sitk
 import SimpleITK.utilities as sitkutils
 from numpy.testing import assert_allclose
-import vtk
 
 
 def test_Logger():
@@ -35,31 +32,6 @@ def test_slice_by_slice():
 
     for z in range(img.GetSize()[2]):
         assert img[0, 0, z] == z
-
-
-def test_sitktovtk():
-    img = sitk.Image([10, 10, 5], sitk.sitkFloat32)
-    img = img + 42.0
-    vtk_img = sitkutils.sitk2vtk(img)
-
-    # free the SimpleITK image's memory
-    img = None
-    gc.collect()
-
-    assert vtk_img.GetScalarComponentAsFloat(0, 0, 0, 0) == 42.0
-
-
-def test_vtktositk():
-    source = vtk.vtkImageSinusoidSource()
-    source.Update()
-    img = source.GetOutput()
-
-    sitkimg = sitkutils.vtk2sitk(img)
-    source = None
-    img = None
-    gc.collect()
-
-    assert sitkimg[0, 0, 0] == 255.0
 
 
 def test_fft_initialization():

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -1,0 +1,29 @@
+import SimpleITK as sitk
+from SimpleITK.utilities.vtk import sitk2vtk, vtk2sitk
+import vtk
+import gc
+
+
+def test_sitktovtk():
+    img = sitk.Image([10, 10, 5], sitk.sitkFloat32)
+    img = img + 42.0
+    vtk_img = sitk2vtk(img)
+
+    # free the SimpleITK image's memory
+    img = None
+    gc.collect()
+
+    assert vtk_img.GetScalarComponentAsFloat(0, 0, 0, 0) == 42.0
+
+
+def test_vtktositk():
+    source = vtk.vtkImageSinusoidSource()
+    source.Update()
+    img = source.GetOutput()
+
+    sitkimg = vtk2sitk(img)
+    source = None
+    img = None
+    gc.collect()
+
+    assert sitkimg[0, 0, 0] == 255.0


### PR DESCRIPTION
Move sitk2vtk to vtk submodule

Removed the import of the large vtk package when importing Simpleitk.utilities. This can improve performance when vtk is not needed when using other provided utilities. This follow the pattern of other optional dependencies for the Utilities.
