### PR TITLE
Create separate publish GH Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,11 +60,8 @@ jobs:
 
   publish:
     needs: test
-    name: Upload release to PyPI
+    name: Create Artifact
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: write
     steps:
     - uses: actions/checkout@v3
       with:
@@ -85,19 +82,3 @@ jobs:
       with:
         name: python-packages
         path: dist
-    - name: Create Release and Upload
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh release create ${{ github.ref_name }} --repo ${{ github.repository }} --verify-tag --generate-notes --title "Release ${{ github.ref_name }}"
-        gh release upload ${{ github.ref_name }} --repo ${{ github.repository }} dist/*
-
-
-    - name: PyPI Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      # hash for release/v1.8
-      uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish
+
+
+jobs:
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    name: Upload release to Github Releases and PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: publish
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Build package
+      run: |
+        python -m pip install twine build
+        python -m build --wheel --sdist
+        python -m twine check dist/*
+        ls -la dist
+    - name: Create Release and Upload
+      id: create_release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create ${{ github.ref_name }} --repo ${{ github.repository }} --verify-tag --generate-notes --title "Release ${{ github.ref_name }}"
+        gh release upload ${{ github.ref_name }} --repo ${{ github.repository }} dist/*
+
+
+    - name: PyPI Publish package
+      # hash for release/v1.8
+      uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pushes packages to the GitHub Releases page and to PyPI.