### PR TITLE
Update the sitk2vtk test to test memory allocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e .[vtk,dask,pyside] -r test/requirements.txt
+        sudo apt-get update
         sudo apt install libegl1
 
     - name: Test with pytest

--- a/SimpleITK/utilities/vtk.py
+++ b/SimpleITK/utilities/vtk.py
@@ -77,7 +77,7 @@ def sitk2vtk(image: sitk.Image) -> vtk.vtkImageData:
         vtk_image.SetDirectionMatrix(direction)
 
     # Set pixel data
-    depth_array = vtknp.numpy_to_vtk(sitk.GetArrayViewFromImage(image).ravel())
+    depth_array = vtknp.numpy_to_vtk(sitk.GetArrayFromImage(image).ravel())
     depth_array.SetNumberOfComponents(ncomp)
     vtk_image.GetPointData().SetScalars(depth_array)
 

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -1,4 +1,5 @@
 import math
+import gc
 
 import SimpleITK as sitk
 import SimpleITK.utilities as sitkutils
@@ -37,7 +38,14 @@ def test_slice_by_slice():
 
 def test_sitktovtk():
     img = sitk.Image([10, 10, 5], sitk.sitkFloat32)
+    img = img + 42.0
     vtk_img = sitkutils.sitk2vtk(img)
+
+    # free the SimpleITK image's memory
+    img = None
+    gc.collect()
+
+    assert vtk_img.GetScalarComponentAsFloat(0, 0, 0, 0) == 42.0
 
 
 def test_fft_initialization():


### PR DESCRIPTION
This test fails on my Windows system when sitk2vtk uses sitk.GetArrayViewFromImage instead of sitk.GetArrayFromImage.